### PR TITLE
Fix focus issue when opening QR code modal

### DIFF
--- a/frontend/src/pages/Connections/index.js
+++ b/frontend/src/pages/Connections/index.js
@@ -151,10 +151,13 @@ const Connections = () => {
 		setSelectedWhatsApp(null);
 	}, [setSelectedWhatsApp, setWhatsAppModalOpen]);
 
-	const handleOpenQrModal = whatsApp => {
-		setSelectedWhatsApp(whatsApp);
-		setQrModalOpen(true);
-	};
+        const handleOpenQrModal = whatsApp => {
+                if (document.activeElement) {
+                        document.activeElement.blur();
+                }
+                setSelectedWhatsApp(whatsApp);
+                setQrModalOpen(true);
+        };
 
 	const handleCloseQrModal = useCallback(() => {
 		setSelectedWhatsApp(null);


### PR DESCRIPTION
## Summary
- blur the active element before opening the QR code modal so Material UI can set `aria-hidden` on the main `#root` element without a focus conflict.

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ebb46b1e48326a5f0df0ec56fad2d