### PR TITLE
Fix baileys store import path

### DIFF
--- a/backend/src/libs/wbot.ts
+++ b/backend/src/libs/wbot.ts
@@ -11,7 +11,7 @@ import makeWASocket, {
   jidNormalizedUser,
   CacheStore
 } from "@whiskeysockets/baileys";
-import { makeInMemoryStore } from "@whiskeysockets/baileys/lib/Store";
+import { makeInMemoryStore } from "@whiskeysockets/baileys";
 import { Op } from "sequelize";
 import { FindOptions } from "sequelize/types";
 import Whatsapp from "../models/Whatsapp";


### PR DESCRIPTION
## Summary
- fix import path for `makeInMemoryStore` in wbot

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec27d27708326b31d1be3109c8c6e